### PR TITLE
[Refactor] Harden against pathological strings

### DIFF
--- a/implementation.js
+++ b/implementation.js
@@ -27,7 +27,7 @@ var isClass = function isClassConstructor(fn) {
 	return false;
 };
 
-var regex = /\s*function\s+([^(\s]*)\s*/;
+var regex = /\s?function\s+([^(\s]*)\s*/;
 
 var functionProto = Function.prototype;
 

--- a/implementation.js
+++ b/implementation.js
@@ -27,7 +27,7 @@ var isClass = function isClassConstructor(fn) {
 	return false;
 };
 
-var regex = /\s?function\s+([^(\s]*)\s*/;
+var regex = /^\s*function\s+([^(\s]*)\s*/;
 
 var functionProto = Function.prototype;
 

--- a/implementation.js
+++ b/implementation.js
@@ -44,7 +44,7 @@ module.exports = function getName() {
 	}
 	var str = $functionToString(this);
 	var match = $stringMatch(str, regex);
-	var name = match && match[1];
+	var name = (match && match[1]) || '';
 
 	return /** @type {string} */ (name);
 };

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
 		"make-arrow-function": "^1.2.0",
 		"make-async-function": "^1.0.0",
 		"make-generator-function": "^2.1.0",
+		"mock-property": "^1.1.2",
 		"npmignore": "^0.3.5",
 		"nyc": "^10.3.2",
 		"safe-publish-latest": "^2.0.0",

--- a/test/implementation.js
+++ b/test/implementation.js
@@ -41,19 +41,15 @@ test('as a function', function (t) {
 		st.end();
 	});
 
-	t.test('pathological function', function (st) {
+	t.test('pathological function', { ignoreSyncTimeout: false }, function (st) {
 		var func = eval('(function(){' + new Array(100001).join(' ') + '})'); // eslint-disable-line no-eval
 
 		var restoreName = mockProperty(func, 'name', { 'delete': true });
-		t.teardown(restoreName);
+		st.teardown(restoreName);
 
-		var start = Date.now();
+		st.timeoutAfter(250);
 		var result = getName(func);
-		var elapsed = Date.now() - start;
-
 		st.equal(result, '', 'function with no name has the name ""');
-		st.ok(elapsed < 250, 'completes in linear time (took ' + elapsed + 'ms)');
-
 		st.end();
 	});
 

--- a/test/implementation.js
+++ b/test/implementation.js
@@ -23,7 +23,8 @@ test('as a function', function (t) {
 			['foo', eval('(function foo () {/* named with space */})')],
 			['foo', eval('(function foo() {/* named without space */})')],
 			['', eval('(function () {/* anonymous with space */})')],
-			['', eval('(function() {/* anonymous without space */})')]
+			['', eval('(function() {/* anonymous without space */})')],
+			['', eval('(function() {/* function foo */})')]
 		];
 		/* eslint-enable no-eval */
 

--- a/test/implementation.js
+++ b/test/implementation.js
@@ -14,7 +14,23 @@ test('as a function', function (t) {
 		st.end();
 	});
 
-	runTests(callBind(implementation), t);
+	var getName = callBind(implementation);
+
+	t.test('pathological function', function (st) {
+		var func = eval('(function(){' + new Array(100001).join(' ') + '})'); // eslint-disable-line no-eval
+		delete func.name;
+
+		var start = Date.now();
+		var result = getName(func);
+		var elapsed = Date.now() - start;
+
+		st.equal(result, null, 'anonymous function with no name has the name of null');
+		st.ok(elapsed < 250, 'completes in linear time (took ' + elapsed + 'ms)');
+
+		st.end();
+	});
+
+	runTests(getName, t);
 
 	t.end();
 });

--- a/test/implementation.js
+++ b/test/implementation.js
@@ -5,6 +5,7 @@ var callBind = require('call-bind');
 var test = require('tape');
 var hasStrictMode = require('has-strict-mode')();
 var forEach = require('for-each');
+var mockProperty = require('mock-property');
 var runTests = require('./tests');
 
 test('as a function', function (t) {
@@ -30,16 +31,21 @@ test('as a function', function (t) {
 
 		forEach(functions, function (testCase) {
 			var name = testCase[0];
-			var fn = testCase[1];
-			delete fn.name;
-			st.equal(getName(fn), name, 'function with no name has the name "' + name + '"');
+			var func = testCase[1];
+
+			var restoreName = mockProperty(func, 'name', { 'delete': true });
+			t.teardown(restoreName);
+
+			st.equal(getName(func), name, 'function with no name has the name "' + name + '"');
 		});
 		st.end();
 	});
 
 	t.test('pathological function', function (st) {
 		var func = eval('(function(){' + new Array(100001).join(' ') + '})'); // eslint-disable-line no-eval
-		delete func.name;
+
+		var restoreName = mockProperty(func, 'name', { 'delete': true });
+		t.teardown(restoreName);
 
 		var start = Date.now();
 		var result = getName(func);
@@ -50,6 +56,7 @@ test('as a function', function (t) {
 
 		st.end();
 	});
+
 	runTests(getName, t);
 
 	t.end();

--- a/test/implementation.js
+++ b/test/implementation.js
@@ -4,6 +4,7 @@ var implementation = require('../implementation');
 var callBind = require('call-bind');
 var test = require('tape');
 var hasStrictMode = require('has-strict-mode')();
+var forEach = require('for-each');
 var runTests = require('./tests');
 
 test('as a function', function (t) {
@@ -16,6 +17,25 @@ test('as a function', function (t) {
 
 	var getName = callBind(implementation);
 
+	t.test('functions without name property', function (st) {
+		/* eslint-disable no-eval */
+		var functions = [
+			['foo', eval('(function foo () {/* named with space */})')],
+			['foo', eval('(function foo() {/* named without space */})')],
+			['', eval('(function () {/* anonymous with space */})')],
+			['', eval('(function() {/* anonymous without space */})')]
+		];
+		/* eslint-enable no-eval */
+
+		forEach(functions, function (testCase) {
+			var name = testCase[0];
+			var fn = testCase[1];
+			delete fn.name;
+			st.equal(getName(fn), name, 'function with no name has the name "' + name + '"');
+		});
+		st.end();
+	});
+
 	t.test('pathological function', function (st) {
 		var func = eval('(function(){' + new Array(100001).join(' ') + '})'); // eslint-disable-line no-eval
 		delete func.name;
@@ -24,12 +44,11 @@ test('as a function', function (t) {
 		var result = getName(func);
 		var elapsed = Date.now() - start;
 
-		st.equal(result, null, 'anonymous function with no name has the name of null');
+		st.equal(result, '', 'function with no name has the name ""');
 		st.ok(elapsed < 250, 'completes in linear time (took ' + elapsed + 'ms)');
 
 		st.end();
 	});
-
 	runTests(getName, t);
 
 	t.end();


### PR DESCRIPTION
Change a regular expression for matching the function name to avoid potential quadratic runtime in the `getName` function due to a pathological function name.